### PR TITLE
Add '--profile' Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ See chapter [Flags and Arguments](#flags-and-arguments) for an overview of all a
 |--help|Show help text|
 |--max-retries|Maximum number of retries (default: 3)|
 |--no-input|Do not require any input|
+|--profile|AWS profile to use|
 |--region|AWS region of DynamoDB table (overwrite default region)|
 |--version|Show version number and quit|
 


### PR DESCRIPTION
This PR will add the `--profile` flag. This worked pretty well during my tests. The one thing that might become a problem is that you can't define the credentials file from which credentials should be loaded. This limits the usefulness of this PR a bit, but for most use cases it still should be useful.

Fixes #10 #9 