### PR TITLE
Add '--quiet' Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See chapter [Flags and Arguments](#flags-and-arguments) for an overview of all a
 |--max-retries|Maximum number of retries (default: 3)|
 |--no-input|Do not require any input|
 |--profile|AWS profile to use|
+|--quiet|Disable all output (except for required input)|
 |--region|AWS region of DynamoDB table (overwrite default region)|
 |--version|Show version number and quit|
 


### PR DESCRIPTION
Adds a new flag to disable all output (except for when `ddbt` needs to ask the user a question and the user did _not_ use the `--no-input` flag).

Fixes #3 