### PR TITLE
Build Release Artefacts for Apple Silicon

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,8 +15,28 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: 386
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
 archives:
-  - replacements:
+  -
+    format_overrides:
+      - goos: windows
+        format: zip
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ before:
 builds:
   -
     main: cmd/ddbt/main.go
+    ldflags:
+      - -s -w
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
This PR updates the goreleaser configuration to also produce `darwin/arm64` binaries that will run natively on Apple Silicon CPUs.

The current release table looks like this:


  | Linux | Windows | macOS
-- | -- | -- | --
i386 | ✅ | ✅ | ❌
x86_64 | ✅ | ✅ | ✅
arm | ✅ | ❌ | ❌
arm64 | ✅ | ❌ | ✅

This PR will also switch the archive format for the Windows builds from `.tar.gz` to `.zip`.