### PR TITLE
Add Documentation for --no-color Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See chapter [Flags and Arguments](#flags-and-arguments) for an overview of all a
 |--help|Show help text|
 |--max-retries|Maximum number of retries (default: 3)|
 |--no-input|Do not require any input|
+|--no-color|Disable colored output|
 |--profile|AWS profile to use|
 |--quiet|Disable all output (except for required input)|
 |--region|AWS region of DynamoDB table (overwrite default region)|

--- a/cmd/ddbt/main.go
+++ b/cmd/ddbt/main.go
@@ -42,6 +42,7 @@ Options:
   --help		This help text
   --max-retries		Maximum number of retries (default: 3)
   --no-input		Do not require any input
+  --no-color		Disable colored output
   --profile		AWS profile to use
   --quiet		Disable all output (except for required input)
   --region		AWS region of DynamoDB table (overwrite default region)


### PR DESCRIPTION
Just a minor patch to add missing documentation.

Closes #26