### PR TITLE
Rename module

### DIFF
--- a/cmd/ddbt/main_test.go
+++ b/cmd/ddbt/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
-	"ddbt/internal"
+	"github.com/jenslauterbach/ddbt/internal"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ddbt
+module github.com/jenslauterbach/ddbt
 
 go 1.16
 

--- a/tools/testdata/main.go
+++ b/tools/testdata/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"ddbt/internal"
+	"github.com/jenslauterbach/ddbt/internal"
 	"flag"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"


### PR DESCRIPTION
The old module path 'ddbt' was chosen poorly, when I started the project. The new name is aligned with other projects and with what the documentation recommends.

See: https://go.dev/ref/mod#glos-module-path